### PR TITLE
Update of spellcheck GitHub Action to version 0.32.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: rojopolis/spellcheck-github-actions@0.5.0
+    - uses: rojopolis/spellcheck-github-actions@0.32.0
       name: Spellcheck
 
   StyleCheck:

--- a/.spellcheck.yml
+++ b/.spellcheck.yml
@@ -9,10 +9,10 @@ matrix:
   pipeline:
   - pyspelling.filters.markdown:
   - pyspelling.filters.html:
-    comments: false
-    ignores:
-    - code
-    - pre
+      comments: false
+      ignores:
+      - code
+      - pre
   sources:
   - '**/*.md'
   default_encoding: utf-8


### PR DESCRIPTION
Hello

As the maintainer of the [spellcheck GitHub action](https://github.com/marketplace/actions/github-spellcheck-action) I am in the process of  _sunsetting_ some older version as by the proposed [sunset policy](https://github.com/rojopolis/spellcheck-github-actions/wiki#sunset-policy)

I just updated the action to version 0.32.0, so this PR offers an update to the latest version, since I found out that you are using an older version.

I have spotted that in some of the older releases, since 0.5.0 to be exact, the use of the Docker image has not been working as expected, so with this update the version should of the action should match the proper version of the Docker image.

Let me know if you have any issues with the proposed PR and I will do my best to accommodate.

I can recommend [Dependabot](https://github.com/dependabot) for keeping your GitHub actions up to date, alternatively there are [Renovate](https://github.com/marketplace/renovate), if you want a PR proposing a basic configuration for Dependabot, please let me know.

Alternatively you can point to the canonical version `v0`, then you get updates automatically.

jonasbn